### PR TITLE
Enable functionality for all title lists

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   
   "content_scripts": [
     {
-      "matches": ["http://www.imdb.com/*/watchlist*"],
+      "matches": ["http://www.imdb.com/*/watchlist*", "http://www.imdb.com/list/*"],
       "run_at": "document_end",
       "css": ["warzat.css","ui-lightness/jquery-ui-1.9.2.custom.min.css"],
       "js": ["lib/jquery-1.8.3.min.js","lib/jquery-ui-1.9.2.custom.min.js",

--- a/warzat.js
+++ b/warzat.js
@@ -506,7 +506,7 @@ function isServiceEnabled(serviceId) {
 ////////////////////////////////////////////////////////////////////////////////
 // MAIN
 
-var compactList = $("div.list.compact");
+var compactList = $("div.list_titles div.list.compact");
 var maxRows = optionValues["search-limit"];
 
 if (compactList.length > 0) {


### PR DESCRIPTION
Thanks for this useful extension!

This adds the extension functionality to all lists of titles. I keep several lists beyond my watchlist so having this everywhere is pretty great, and you can also search in other people's (public) lists. The `div.list.compact` selector was modified to prevent things from going awry on e.g. lists of actors.
