### PR TITLE
Remove the header row before searching

### DIFF
--- a/warzat.js
+++ b/warzat.js
@@ -531,6 +531,8 @@ if (compactList.length > 0) {
 		}
 		
 		var rows = $.makeArray($("tr.list_item"));
+		// Remove header row.
+		rows.shift();
 		if (rows.length > maxRows) {
 			rows.splice(maxRows);
 		}


### PR DESCRIPTION
I noticed the count was off by 1 when searching, this removes the header row first.
